### PR TITLE
Add YAML separator enforcement script

### DIFF
--- a/scripts/ensure-yaml-separator.sh
+++ b/scripts/ensure-yaml-separator.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_DIR="kubernetes"
+
+find "$TARGET_DIR" -type f -name '*.yaml' | while read -r file; do
+    first_line=$(head -n 1 "$file" || true)
+    if [[ "$first_line" != "---"* ]]; then
+        sed -i '1i ---' "$file"
+        echo "Added '---' to $file"
+    fi
+done


### PR DESCRIPTION
## Summary
- add script to ensure all kubernetes YAML files begin with `---`

## Testing
- `shellcheck scripts/ensure-yaml-separator.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856959846f0832c8f4f1fcc26217563