### PR TITLE
Fix rebuild-kustomizations empty config issue

### DIFF
--- a/scripts/rebuild-kustomizations.sh
+++ b/scripts/rebuild-kustomizations.sh
@@ -34,13 +34,8 @@ EOF
         yamlfix kustomization.yaml
         cd ${_gitdir}
     else
-        cat <<EOF >kustomization.yaml
-# yaml-language-server: \$schema=https://json.schemastore.org/kustomization
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources: []
-EOF
+        # Remove lingering kustomization files when no resources are present
+        rm -f kustomization.yaml
     fi
     cd ${_gitdir}
 done


### PR DESCRIPTION
## Summary
- avoid creating an empty kustomization.yaml when the repository folder has no files

## Testing
- `bash -n scripts/rebuild-kustomizations.sh`

------
https://chatgpt.com/codex/tasks/task_e_6856987aa998832cb05a01a89a31f883