### PR TITLE
chore: use bitnamilegacy mariadb images

### DIFF
--- a/kubernetes/apps/productivity/webtrees/db/helmrelease.yaml
+++ b/kubernetes/apps/productivity/webtrees/db/helmrelease.yaml
@@ -35,10 +35,19 @@ spec:
             secretKeyRef:
               name: mariadb-secret
               key: mariadb-root-password
+    image:
+      repository: bitnamilegacy/mariadb
     volumePermissions:
       enabled: true
+      image:
+        repository: bitnamilegacy/os-shell
+    metrics:
+      image:
+        repository: bitnamilegacy/mysqld-exporter
     global:
       storageClass: ${MAIN_SC}
+      security:
+        allowInsecureImages: true
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
## Summary
- migrate webtrees mariadb image references to bitnamilegacy registry per bitnami/charts#35164

## Testing
- `yamllint -d '{extends: default, rules: {line-length: {max: 120}}}' kubernetes/apps/productivity/webtrees/db/helmrelease.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68944b718878832cbb8829e784ed7502