### PR TITLE
fix: prevent duplicate Renovate registryUrls warning

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -162,7 +162,7 @@
         "/(^|/).+\\.ya?ml(?:\\.j2)?$/",
       ],
       matchStrings: [
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)( repository=(?<registryUrl>\\S+))?\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+(:\\s|=)(&\\S+\\s)?(?<currentValue>\\S+)",
         "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+/(?<currentValue>(v|\\d)[^/]+)",
       ],
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",


### PR DESCRIPTION
## Summary
- avoid capturing repository URLs in Renovate custom regex manager to prevent duplicate registryUrls

## Testing
- `npx --yes json5 -c .renovaterc.json5 && echo "config valid"`


------
https://chatgpt.com/codex/tasks/task_e_68945d050368832c95bb59e0f4e31d8d