### PR TITLE
fix(renovate): add explicit digest pinning rule

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -37,6 +37,15 @@
   },
   packageRules: [
     {
+      description: "Pin Docker digests",
+      matchDatasources: ["docker"],
+      rangeStrategy: "pin",
+      semanticCommitType: "chore",
+      semanticCommitScope: "container",
+      commitMessageTopic: "pin image {{depName}}",
+      commitMessageExtra: "digest",
+    },
+    {
       description: "Automerge patch updates",
       matchUpdateTypes: ["patch"],
       automerge: true,


### PR DESCRIPTION
## Summary
- Add package rule to force digest pinning for Docker images that don't already have digests pinned
- Addresses issue #1206 by ensuring Renovate creates PRs to pin digests for all Docker images

## Changes
- Added explicit `rangeStrategy: "pin"` rule for Docker images in `.renovaterc.json5`
- Configured proper commit message format for digest pinning PRs

## Test plan
- [ ] Verify Renovate configuration is valid
- [ ] Wait for next Renovate run to create digest pinning PRs
- [ ] Confirm digest pins are added to Docker images without digests

🤖 Generated with [Claude Code](https://claude.ai/code)