### PR TITLE
fix(bootstrap): eliminate duplicate kubeconfig contexts

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -12,7 +12,8 @@ tasks:
       - talhelper gencommand apply --extra-flags="--insecure" | bash
       - until talhelper gencommand bootstrap | bash; do sleep 10; done
       - until talhelper gencommand kubeconfig --extra-flags="{{.ROOT_DIR}} --force" | bash; do sleep 10; done
-      - cp {{.KUBECONFIG}} "/Users/$USER/Library/Mobile Documents/com~apple~CloudDocs/Dateien/Allgemein/kubectl/$(yq .clusterName {{.TALOS_DIR}}/talconfig.yaml).yaml"
+      - sed -i '' 's/kubernetes/turingpi/g' {{.KUBECONFIG}}
+      - cp {{.KUBECONFIG}} "/Users/$USER/Library/Mobile Documents/com~apple~CloudDocs/Dateien/Allgemein/kubectl/turingpi.yaml"
     preconditions:
       - test -f {{.ROOT_DIR}}/.sops.yaml
       - test -f {{.SOPS_AGE_KEY_FILE}}

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -1,6 +1,5 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
 ---
-clusterName: turingpi
 
 talosVersion: "${talosVersion}"
 kubernetesVersion: "${kubernetesVersion}"


### PR DESCRIPTION
## Summary
- Remove duplicate kubernetes/turingpi contexts in generated kubeconfig
- Streamlines bootstrap process to create single clean context
- Fixes confusion from having two identical clusters with different names

## Changes
- **talconfig.yaml**: Removed `clusterName: turingpi` to use default "kubernetes" name
- **bootstrap/Taskfile.yaml**: Added sed command to rename "kubernetes" → "turingpi" after generation
- **bootstrap/Taskfile.yaml**: Updated kubeconfig copy path to use hardcoded "turingpi.yaml" 

## Result
Bootstrap process now generates clean kubeconfig with single `admin@turingpi` context instead of duplicate `admin@kubernetes` and `admin@turingpi` contexts pointing to the same cluster.

## Test plan
- [ ] Run bootstrap process on fresh cluster
- [ ] Verify kubeconfig contains only `admin@turingpi` context
- [ ] Confirm cluster connectivity works properly

🤖 Generated with [Claude Code](https://claude.ai/code)